### PR TITLE
Add InputPlumber service on startup

### DIFF
--- a/usr/lib/systemd/system-preset/50-playtron.preset
+++ b/usr/lib/systemd/system-preset/50-playtron.preset
@@ -3,4 +3,5 @@ enable create-swap.service
 enable lightdm.service
 enable NetworkManager-wait-online.service
 enable resize-root-file-system.service
+enable inputplumber.service
 disable firewalld.service


### PR DESCRIPTION
This change adds the InputPlumber service to start on system boot. This change is also required to include the InputPlumber package: https://github.com/playtron-os/playtron-os/pull/81