### PR TITLE
add and source playtron specific versioning info

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -37,6 +37,9 @@ function system-info {
 
 	# Operating system
 	source /etc/os-release
+	if [ -f /usr/lib/os-release-playtron ]; then
+		source /usr/lib/os-release-playtron
+	fi
 	OS_NAME=$NAME
 	OS_VERSION=$VERSION_ID
 

--- a/usr/lib/os-release-playtron
+++ b/usr/lib/os-release-playtron
@@ -1,0 +1,2 @@
+NAME=PlaytronOS
+VERSION_ID=0.10.4.18


### PR DESCRIPTION
Overriding the Fedora `os-release` file is rather involved due to all the package dependencies and so was set aside.

But having version info will be very useful, so instead, source version info from a playtron specific location for now.

Will need to update the `playtron-os-files` package with every build. Perhaps we should also align the package version with the OS version.