### PR TITLE
PTCORE-222 add extended option to system-info with resolution

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -58,9 +58,20 @@ function system-info {
 	grep -v "/run/media/rootfs." | \
 	grep -v "/run/media/esp." | tr -s " ")
 
+	# Resolution
+	RES_WIDTH=$(xwininfo -root | grep -e "Width" | cut -d":" -f2 | tr -d ' ')
+	RES_HEIGHT=$(xwininfo -root | grep -e "Height" | cut -d":" -f2 | tr -d ' ')
 
 	# output json
-	echo "{
+	echo "{"
+
+	if [ "$1" == "extended" ]; then
+		echo -n "
+	\"resolutionWidth\": $RES_WIDTH,
+	\"resolutionHeight\": $RES_HEIGHT,"
+	fi
+
+	echo "
 	\"vendor\": \"$MANUFACTURER\",
 	\"model\": \"$MODEL\",
 	\"formFactor\": \"$FORM_FACTOR\",


### PR DESCRIPTION
Only part of PTCORE-222.
This allows playserve to obtain the system's screen resolution.

Tested on my Fedora Silverblue Desktop and my Aya Neo Mini PC with PlaytronOS 0.12.1.21.

Introduces an `extended` option to the `hwctl system-info` command for backwards compatibility.