### PR TITLE
Remove Legion Go udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ Device tweaks:
 
 - ./usr/lib/udev/rules.d/50-block-scheduler.rules
     - Use the Kyber I/O scheduler for NVMe drives
-- ./usr/lib/udev/rules.d/50-lenovo-legion-controller.rules
-    - Fixes controller on Legion Go
-
 
 ## License
 

--- a/usr/lib/udev/rules.d/50-lenovo-legion-controller.rules
+++ b/usr/lib/udev/rules.d/50-lenovo-legion-controller.rules
@@ -1,2 +1,0 @@
-# Lenovo Legion Go
-ACTION=="add", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6182", RUN+="/sbin/modprobe xpad" RUN+="/bin/sh -c 'echo 17ef 6182 > /sys/bus/usb/drivers/xpad/new_id'"


### PR DESCRIPTION
They are available upstream as of Linux 6.8-rc3. The latest PlaytronOS build is using Linux 6.8.11.