### PR TITLE
allow hwctl to be called with pkexec

### DIFF
--- a/usr/share/polkit-1/rules.d/50-one.playtron.hwctl.rules
+++ b/usr/share/polkit-1/rules.d/50-one.playtron.hwctl.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" && subject.isInGroup("wheel") && action.lookup("program") == "/usr/bin/hwctl") {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
Allow hwctl to be run with pkexec. Needed so playserve can do drive formatting without requiring a password.