### PR TITLE
Various hwctl improvements

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -322,6 +322,9 @@ function audio {
 
 function display {
 	case $1 in
+		"has-brightness-control")
+			brightnessctl --class=backlight get &> /dev/null
+			;;
 		"raise-brightness")
 			brightnessctl --class=backlight set +5% > /dev/null
 			;;

--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -339,22 +339,18 @@ function audio {
 			case $? in
 				0)
 					# set volume to a specific % value
-					echo "case: ABS"
 					wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ ${value}%
 					;;
 				1)
 					# raise volume a relative % amount
-					echo "case: +"
 					wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ ${value}%+
 					;;
 				2)
 					# lower volume a relative % amount
-					echo "case: -"
 					wpctl set-volume @DEFAULT_AUDIO_SINK@ ${value}%-
 					;;
 				*)
 					# validation error
-					echo 'case: ERROR'
 					echo $value
 					;;
 			esac

--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -291,6 +291,37 @@ function storage {
 	esac
 }
 
+function validate_value {
+	if ! [[ "$1" =~ ^[-+]?[0-9]+$ ]]; then
+		echo "Value must be an integer or start with '-' or '+' for relative values"
+		return 3
+	fi
+
+	value=$1
+	if [[ "$value" =~ ^\+ ]]; then
+		value=$(echo "$value" | sed 's/+//' )
+		raise=1
+	elif [[ "$value" =~ ^- ]]; then
+		value=$(echo "$value" | sed 's/-//' )
+		lower=1
+	fi
+
+	if [ "$value" -lt 0 ] || [ "$value" -gt 100 ]; then
+		echo "Absolute value must be between 0 and 100"
+		return 3
+	fi
+
+	echo $value
+
+	if [ "$raise" == 1 ]; then
+		return 1
+	elif [ "$lower" == 1 ]; then
+		return 2
+	else
+		return 0
+	fi
+}
+
 function audio {
 	case $1 in
 		"raise-volume")
@@ -304,12 +335,29 @@ function audio {
 			echo "scale=0; $float * 100 / 1" | bc
 			;;
 		"set-volume")
-			if [ "$2" -ge 0 ] 2>/dev/null && [ "$2" -le 100 ] 2>/dev/null; then
-				wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ ${2}%
-			else
-				echo "ERROR: value must be between 0 and 100"
-				exit 1
-			fi
+			value=$(validate_value $2)
+			case $? in
+				0)
+					# set volume to a specific % value
+					echo "case: ABS"
+					wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ ${value}%
+					;;
+				1)
+					# raise volume a relative % amount
+					echo "case: +"
+					wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ ${value}%+
+					;;
+				2)
+					# lower volume a relative % amount
+					echo "case: -"
+					wpctl set-volume @DEFAULT_AUDIO_SINK@ ${value}%-
+					;;
+				*)
+					# validation error
+					echo 'case: ERROR'
+					echo $value
+					;;
+			esac
 			;;
 		"toggle-mute")
 			wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
@@ -339,12 +387,25 @@ function display {
 			fi
 			;;
 		"set-brightness")
-			if [ "$2" -ge 0 ] 2>/dev/null && [ "$2" -le 100 ] 2>/dev/null; then
-				brightnessctl --class=backlight set ${2}% > /dev/null
-			else
-				echo "ERROR: value must be between 0 and 100"
-				exit 1
-			fi
+			value=$(validate_value $2)
+			case $? in
+				0)
+					# set brightness to a specific % value
+					brightnessctl --class=backlight set ${value}% > /dev/null
+					;;
+				1)
+					# raise brightness a relative % amount
+					brightnessctl --class=backlight set +${value}% > /dev/null
+					;;
+				2)
+					# lower brightness a relative % amount
+					brightnessctl --class=backlight set ${value}%- > /dev/null
+					;;
+				*)
+					# validation error
+					echo $value
+					;;
+			esac
 			;;
 		*)
 			echo "Error: unknown command"


### PR DESCRIPTION
 - added `has-brightness-control` display sub-command to check if brightness controls can be used, addresses https://playtron-one.atlassian.net/browse/PTCORE-2049
   - `hwctl display has-brightness-control` will give a return code of `0` if brightness controls can be used, any other value should be interpreted as brightness controls being unavailable
 - added the ability to raise and lower brightness and volume by a specific relative amount, some examples:
   - `hwctl display set-brightness +50` will raise brightness by 50
   - `hwctl display set-brightness -10` will lower brightness by 10
   - `hwctl display set-brightness 30` will set the brightness to 30 (existing functionality)
   - `hwctl audio set-volume +10` will raise audio volume by 10


Being able to set the relative value is meant to address https://playtron-one.atlassian.net/browse/PTCORE-1996.
The UI is currently trying to set the value directly, but because we are working with scaled values, the exact value requested by the UI is not the value that is actually set. This difference causes the UI to get stuck at certain values. Further work is needed on the UI side to use this new functionality to fully address the issue.