### PR TITLE
make the playtron-os system `read-only`

### DIFF
--- a/etc/read-only.sh
+++ b/etc/read-only.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mount -o remount,ro /

--- a/usr/lib/systemd/system/read-only.service
+++ b/usr/lib/systemd/system/read-only.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Remount Root Filesystem as Read-Only
+ConditionPathExists=/etc/read-only.sh
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mount -o remount,ro /
+ExecStop=/bin/mount -o remount,rw /
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/read-only.service
+++ b/usr/lib/systemd/system/read-only.service
@@ -1,12 +1,10 @@
 [Unit]
-Description=Remount Root Filesystem as Read-Only
-ConditionPathExists=/etc/read-only.sh
+Description= Read-only service
 After=local-fs.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/mount -o remount,ro /
-ExecStop=/bin/mount -o remount,rw /
+ExecStart=/bin/bash /etc/read-only.sh
 RemainAfterExit=true
 
 [Install]


### PR DESCRIPTION
Configuring Playtron-OS as read-only prevents modifications to the root filesystem, enhancing system stability and security by ensuring core files remain unchanged.