### PR TITLE
PTCORE-1850 fix disk permissions when formatting

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -225,8 +225,8 @@ function storage {
 		if ! mount | grep "${partition_to_format}" > /dev/null; then
 			echo "INFO: Drive was not automounted; mounting manually"
 			mkdir ${mount_point}
-			chown playtron ${mount_point}
-			mount ${partition_to_format} ${mount_point}
+			mount -o users ${partition_to_format} ${mount_point}
+			chown -R playtron:playtron ${mount_point}
 		fi
 	}
 


### PR DESCRIPTION
This seems to do the trick and fixes permissions issues on external drives after formatting and on subsequent boots/mounts. Although I am not quite sure why.