### PR TITLE
Remove Weston shortcuts

### DIFF
--- a/etc/xdg/weston/weston.ini
+++ b/etc/xdg/weston/weston.ini
@@ -7,13 +7,5 @@ icon=/usr/share/weston/icon_terminal.png
 path=/usr/bin/weston-terminal
 
 [launcher]
-icon=/usr/share/icons/hicolor/16x16/apps/firefox.png
-path=/usr/bin/firefox
-
-[launcher]
-icon=/usr/share/icons/hicolor/16x16/apps/steam.png
-path=/usr/bin/steam
-
-[launcher]
 icon=/usr/share/icons/Adwaita/16x16/mimetypes/application-x-executable.png
 path=/usr/bin/playtron-labs


### PR DESCRIPTION
Firefox is no longer installed.

Running the Steam client can cause issues with Playserve.