### PR TITLE
Disable systemd-oomd.service

### DIFF
--- a/usr/lib/systemd/system-preset/50-playtron.preset
+++ b/usr/lib/systemd/system-preset/50-playtron.preset
@@ -5,3 +5,4 @@ enable NetworkManager-wait-online.service
 enable resize-root-file-system.service
 enable inputplumber.service
 disable firewalld.service
+disable systemd-oomd.service


### PR DESCRIPTION
This service will kill off processes when tmpfs becomes fully utilized. Since we only have a few major processes running, this can cause more harm than good.