### PR TITLE
add functionality to set timezone

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -463,10 +463,22 @@ function system-battery {
 	esac
 }
 
+function datetime {
+	case $1 in
+		"set-timezone")
+			timedatectl set-timezone $2
+			;;
+		*)
+			echo "Error: unknown command"
+			;;
+	esac
+}
+
+
 SUBSYSTEM=$1
 shift
 
-if [[ "$SUBSYSTEM" == @(audio|display|system-battery|system-info|storage) ]]; then
+if [[ "$SUBSYSTEM" == @(audio|datetime|display|system-battery|system-info|storage) ]]; then
 	$SUBSYSTEM $@
 else
 	echo "Error: unknown subsystem $SUBSYSTEM"


### PR DESCRIPTION
You can set the timezone with `pkexec hwctl datetime set-timezone <timezone>`

Where `<timezone>` is a value from the list given by `timedatectl list-timezones`.

Tested and working on my local system.