### PR TITLE
Increase open file limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Hardware control:
 - ./usr/bin/hwctl
     - A Bash script to manage audio, battery, display, storage, and system information
 
+Open file and memory mapping limits:
+
+- ./etc/security/limits.d/50-playtron.conf
+    - Increase the open file limit for user processes to 524288.
+- ./usr/lib/sysctl.d/50-playtron.conf
+    - Increase the open file limit for the kernel to 524288.
+    - Increase the mapped memory limit to 16777216.
+
 Resize root file system:
 
 - ./usr/lib/systemd/system/resize-root-file-system.service
@@ -16,7 +24,7 @@ Resize root file system:
 
 Swap creation:
 
-- ./usr/lib/sysctl.d/50-swappiness.conf
+- ./usr/lib/sysctl.d/50-playtron.conf
     - Lower the swappiness to 1
 - ./usr/lib/systemd/system/create-swap.service
     - A systemd service file to run the `create-swap.sh` script once (after the `resize-root-file-system` service finishes) and then disable itself so the service does not run again

--- a/etc/security/limits.d/50-playtron.conf
+++ b/etc/security/limits.d/50-playtron.conf
@@ -1,0 +1,3 @@
+
+*	soft	nofile	524288
+*	hard	nofile	524288

--- a/usr/lib/sysctl.d/50-playtron.conf
+++ b/usr/lib/sysctl.d/50-playtron.conf
@@ -1,0 +1,3 @@
+fs.file-max=524288
+vm.max_map_count=16777216
+vm.swappiness=1

--- a/usr/lib/sysctl.d/50-swappiness.conf
+++ b/usr/lib/sysctl.d/50-swappiness.conf
@@ -1,1 +1,0 @@
-vm.swappiness=1


### PR DESCRIPTION
and increase the allowed number of mapped memory areas a process can use. This helps to get more games running.