### PR TITLE
OS-117 switch display manager to sddm

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Configuration:
     - Enable default system services
 - ./usr/lib/systemd/user-preset/50-playtron.preset
     - Enable default user services
-- ./usr/share/lightdm/lightdm.conf.d/55-playtron.conf
+- ./usr/lib/sddm/sddm.conf.d/55-playtron.conf
     - Autologin to playtron session
 - ./usr/share/polkit-1/rules.d/50-one.playtron.rpmostree1.rules
     - Allow running OS upgrades without a password

--- a/usr/bin/playtron-factory-reset
+++ b/usr/bin/playtron-factory-reset
@@ -62,10 +62,12 @@ rsync -aHX /etc/NetworkManager /tmp/
 # reset some key files in /etc
 reset_etc NetworkManager
 reset_etc systemd
-reset_etc lightdm
+reset_etc sddm
+reset_etc sddm.conf.d
 reset_etc ssh
 reset_etc xdg
 rsync -aHX /usr/etc/gai.conf /etc/gai.conf
+rsync -aHX /usr/etc/sddm.conf /etc/sddm.conf
 
 # reset playtron password
 echo 'playtron:playtron' | chpasswd

--- a/usr/lib/sddm/sddm.conf.d/55-playtron.conf
+++ b/usr/lib/sddm/sddm.conf.d/55-playtron.conf
@@ -1,0 +1,4 @@
+[Autologin]
+User=playtron
+Session=gamescope-session-playtron
+Relogin=true

--- a/usr/lib/systemd/system-preset/50-playtron.preset
+++ b/usr/lib/systemd/system-preset/50-playtron.preset
@@ -1,6 +1,6 @@
 enable clatd-ipv6-check.service
 enable create-swap.service
-enable lightdm.service
+enable sddm.service
 enable NetworkManager-wait-online.service
 enable resize-root-file-system.service
 enable inputplumber.service

--- a/usr/share/lightdm/lightdm.conf.d/55-playtron.conf
+++ b/usr/share/lightdm/lightdm.conf.d/55-playtron.conf
@@ -1,7 +1,0 @@
-[LightDM]
-run-directory=/run/lightdm
-logind-check-graphical=true
-[Seat:*]
-greeter-session=lightdm-autologin-greeter
-autologin-user=playtron
-autologin-session=gamescope-session-playtron


### PR DESCRIPTION
Tested factory reset by updating files manually on an existing PlaytronOS install, creating/editing files in all the sddm related locations under /etc, and running the factory reset script. Then confirming the files/edits were removed.