### PR TITLE
OS-206 add ssh and environment controls

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -580,4 +580,13 @@ if [[ "$SUBSYSTEM" == @(audio|datetime|display|system-battery|system-info|storag
 	$SUBSYSTEM $@
 else
 	echo "Error: unknown subsystem $SUBSYSTEM"
+	echo "Available subsystems:"
+	echo " - audio"
+	echo " - datetime"
+	echo " - display"
+	echo " - system-battery"
+	echo " - system-info"
+	echo " - storage"
+	echo " - ssh"
+	echo " - environment"
 fi

--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -509,10 +509,74 @@ function ssh {
 	esac
 }
 
+CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+ENV_DIR="${CONFIG_HOME}/environment.d"
+
+function environment-set {
+	VAR=$1
+	VALUE=$2
+	if [ -z "$VALUE" ]; then
+		echo "Error: No value specified"
+		exit
+	fi
+
+	ENV_FILE="${ENV_DIR}/${VAR}.conf"
+	mkdir -p ${ENV_DIR}
+	echo "${VAR}=${VALUE}" > ${ENV_FILE}
+}
+
+function environment-clear {
+	VAR=$1
+	ENV_FILE="${ENV_DIR}/${VAR}.conf"
+	if [ -f ${ENV_FILE} ]; then
+		rm ${ENV_FILE}
+	fi
+}
+
+function environment-validate-common {
+	isValidVarName() {
+		echo "$1" | grep -q '^[_[:alpha:]][_[:alpha:][:digit:]]*$'
+	}
+
+	VAR=$1
+	if [ -z "$VAR" ]; then
+		echo "Error: No environment variable specified"
+		exit
+	fi
+
+	if ! isValidVarName "$VAR"; then
+		echo "Error: Invalid environment variable name"
+		exit
+	fi
+}
+
+function environment {
+	if [ "$EUID" -eq 0 ]; then
+		echo "This command cannot be run as root"
+		exit
+	fi
+
+	case $1 in
+		"set")
+			shift
+			environment-validate-common $@
+			environment-set $@
+			;;
+		"clear")
+			shift
+			environment-validate-common $@
+			environment-clear $@
+			;;
+		*)
+			echo "Error: unknown command"
+			;;
+	esac
+}
+
 SUBSYSTEM=$1
 shift
 
-if [[ "$SUBSYSTEM" == @(audio|datetime|display|system-battery|system-info|storage|ssh) ]]; then
+if [[ "$SUBSYSTEM" == @(audio|datetime|display|system-battery|system-info|storage|ssh|environment) ]]; then
 	$SUBSYSTEM $@
 else
 	echo "Error: unknown subsystem $SUBSYSTEM"

--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -495,11 +495,24 @@ function datetime {
 	esac
 }
 
+function ssh {
+	case $1 in
+		"enable")
+			systemctl enable --now sshd
+			;;
+		"disable")
+			systemctl disable --now sshd
+			;;
+		*)
+			echo "Error: unknown command"
+			;;
+	esac
+}
 
 SUBSYSTEM=$1
 shift
 
-if [[ "$SUBSYSTEM" == @(audio|datetime|display|system-battery|system-info|storage) ]]; then
+if [[ "$SUBSYSTEM" == @(audio|datetime|display|system-battery|system-info|storage|ssh) ]]; then
 	$SUBSYSTEM $@
 else
 	echo "Error: unknown subsystem $SUBSYSTEM"


### PR DESCRIPTION
**Why**:
Currently, Grid handles changing log level, the environment (red/black/prod), and enabling/disabling ssh. It does this by using sudo and a password.

Adding this functionality to hwctl allows Grid to call the script without a password or using sudo since hwctl can already be called with elevated privileges using pkexec.

**How**:
 - Added an `ssh` subsystem with `enable` and `disable` commands which call `systemctl`.
 - Added an `environment` subsystem with `set` and `clear` commands which modify config files under `~/.config/environment.d` which is read by the gamescope session at startup.
 - The `environment` subsystem allows setting any environment variable by creating a separate config file based on the environment variable name to prevent the variables overwriting each other, security was considered and addressed by the following measures:
   - The `environment` subsystem cannot be called by root and can only operate on user files
   - The environment variable name that is passed in is validated to prevent someone passing relative path names to trick the script into operating on files in the wrong location.
   - NOTE: `XDG_CONFIG_HOME` is honored, which could be abused, but in that case the whole system is likely compromised and the threat is mitigated by disallowing operation as the root user.


**Testing**:
 - All functionality was tested on my local development machine