### PR TITLE
fix resize root on bootc builds

### DIFF
--- a/usr/bin/resize-root-file-system.sh
+++ b/usr/bin/resize-root-file-system.sh
@@ -6,8 +6,8 @@ set -x
 root_partition=$(mount | grep 'on / ' | awk '{print $1}')
 overlay_detected="false"
 
-# When using OCI builds (not rpm-ostree builds), the file system is overlayed sooner.
-if [ "${root_partition}" == "overlay" ]; then
+# When using OCI and bootc builds (not rpm-ostree builds), the file system is overlayed sooner.
+if [ "${root_partition}" == "overlay" ] || [ "${root_partition}" == "composefs" ]; then
     root_partition=$(mount | grep 'on /var ' | awk '{print $1}')
     overlay_detected="true"
 fi


### PR DESCRIPTION
The `resize-root-file-system` script was failing on bootc builds using composefs.