### PR TITLE
drop rpm-ostree command for bootc

### DIFF
--- a/usr/bin/playtron-factory-reset
+++ b/usr/bin/playtron-factory-reset
@@ -52,9 +52,6 @@ function reset_etc {
 # change cwd to a directory that won't be deleted
 cd /
 
-# clear all package changes
-rpm-ostree reset &> /dev/null
-
 # backup network settings for potential restoration later (they are considered user files)
 rsync -aHX /etc/NetworkManager /tmp/
 


### PR DESCRIPTION
We probably shouldn't merge this until we are no longer shipping `rpm-ostree` in our builds.