### PR TITLE
add inputplumber config overrides

### DIFF
--- a/usr/share/inputplumber/devices/25-playtron-ayaneo_2.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-ayaneo_2.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: AYANEO 2
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: AYANEO 2
+      sys_vendor: AYANEO
+  - dmi_data:
+      product_name: GEEK
+      sys_vendor: AYANEO
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:e4:00.3-4/input0
+      handler: event*
+  - group: gamepad
+    evdev:
+      name: Microsoft X-Box 360 pad
+      phys_path: usb-0000:e4:00.3-4/input0
+      handler: event*
+  - group: keyboard
+    evdev:
+      name: AT Translated Set 2 keyboard
+      phys_path: isa0060/serio0/input0
+      handler: event*
+  - group: imu
+    iio:
+      name: i2c-BMI0160:00
+      mount_matrix:
+        x: [0, -1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+    config:
+      touchscreen:
+        orientation: "right"
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchscreen
+
+# The ID of a device event mapping in the 'event_maps' folder
+capability_map_id: aya4

--- a/usr/share/inputplumber/devices/25-playtron-ayaneo_2s.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-ayaneo_2s.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: AYANEO 2S
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: AYANEO 2S
+      sys_vendor: AYANEO
+  - dmi_data:
+      product_name: GEEK 1S
+      sys_vendor: AYANEO
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:c4:00.3-4/input0
+      handler: event*
+  - group: gamepad
+    evdev:
+      name: Microsoft X-Box 360 pad
+      phys_path: usb-0000:c4:00.3-4/input0
+      handler: event*
+  - group: keyboard
+    evdev:
+      name: AT Translated Set 2 keyboard
+      phys_path: isa0060/serio0/input0
+      handler: event*
+  - group: imu
+    iio:
+      name: i2c-BMI0160:00
+      mount_matrix:
+        x: [0, -1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+    config:
+      touchscreen:
+        orientation: "right"
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchscreen
+
+# The ID of a device event mapping in the 'event_maps' folder
+capability_map_id: aya4

--- a/usr/share/inputplumber/devices/25-playtron-legion_go.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-legion_go.yaml
@@ -1,0 +1,175 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Lenovo Legion Go
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches match. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: "83E1"
+      sys_vendor: LENOVO
+      cpu_vendor: AuthenticAMD
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  ## XInput - Connected 0x6182
+  # Touchpad
+  - group: mouse # Gamepad Mode
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6182
+      interface_num: 1
+  # Gamepad
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6182
+      interface_num: 2
+  - group: gamepad
+    unique: true
+    evdev:
+      name: "{Lenovo Legion Controller for Windows,Generic X-Box pad}"
+      vendor_id: "17ef"
+      product_id: "6182"
+      handler: event*
+  # Block all evdev devices; mouse, touchpad, keyboard
+  - group: gamepad
+    blocked: true
+    unique: false
+    evdev:
+      name: "  Legion Controller for Windows  *"
+      vendor_id: "17ef"
+      product_id: "6182"
+      handler: event*
+
+  ## DInput - Attached 0x6183
+  # Touchpad
+  - group: mouse
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6183
+      interface_num: 1
+  # Gamepad
+  - group: gamepad # Dinput report
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6183
+      interface_num: 0
+  - group: gamepad # XInput report 40Hz
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6183
+      interface_num: 2
+
+  ## DInput - Detached 0x6184
+  # Touchpad
+  - group: mouse
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6184
+      interface_num: 1
+  # Gamepad
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6184
+      interface_num: 0
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6184
+      interface_num: 2
+
+  ## FPS Mode - 0x6185
+  # Touchpad
+  - group: mouse
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6185
+      interface_num: 1
+  # Mouse
+  - group: mouse
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6185
+      interface_num: 1
+  # Keyboard
+  - group: keyboard
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6185
+      interface_num: 0
+  # Gamepad
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6185
+      interface_num: 2
+
+  # IMU
+  # Broken for now --causes IP to hard freeze
+  # Enabling only gyro_3d allows the tablet gyro to work without needing kernel patch
+  # TODO: Find out why this is broken and swap tablet gyro to controller gyro as default.
+  #  - group: imu
+  #    iio:
+  #      name: accel_3d
+  #      mount_matrix:
+  #        # TODO: Reverify on actual hardware
+  #        x: [0, 1, 0]
+  #        y: [-1, 0, 0]
+  #        z: [0, 0, -1]
+  - group: imu
+    iio:
+      name: gyro_3d
+      mount_matrix:
+        # TODO: Reverify on actual hardware
+        x: [0, 1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
+
+  # Touchscreen
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+    config:
+      touchscreen:
+        orientation: "left"
+
+  # Block all evdev devices; mouse, touchpad, gamepad, keyboard
+  - group: gamepad
+    blocked: true
+    unique: false
+    evdev:
+      vendor_id: "17ef"
+      product_id: "618[3-5]"
+      handler: event*
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchpad
+  - touchscreen

--- a/usr/share/inputplumber/devices/25-playtron-msi_claw.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-msi_claw.yaml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: MSI Claw
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches match. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: "Claw A1M"
+      sys_vendor: "Micro-Star International Co., Ltd."
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Extra Buttons
+  - group: keyboard
+    evdev:
+      name: AT Translated Set 2 keyboard
+      phys_path: isa0060/serio0/input0
+
+  # Gamepad
+  - group: gamepad
+    evdev:
+      vendor_id: "0db0"
+      product_id: "1901"
+      phys_path: "usb-0000:00:14.0-9/input0"
+
+  # IMU
+  - group: imu
+    iio:
+      name: accel_3d
+      mount_matrix:
+        # TODO: Reverify on actual hardware
+        x: [0, 1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
+  - group: imu
+    iio:
+      name: gyro_3d
+      mount_matrix:
+        # TODO: Reverify on actual hardware
+        x: [0, 1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
+
+  # Touchscreen
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchscreen
+
+# The ID of a device event mapping in the 'event_maps' folder
+capability_map_id: claw1

--- a/usr/share/inputplumber/devices/25-playtron-rog_ally.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-rog_ally.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: ASUS ROG Ally
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      board_name: RC71L
+      sys_vendor: ASUSTeK COMPUTER INC.
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad # Used for setting attributes on load
+    hidraw:
+      vendor_id: 0x0b05
+      product_id: 0x1abe
+      interface_num: 2
+  - group: gamepad
+    evdev:
+      name: Microsoft X-Box 360 pad
+      vendor_id: 045e
+      product_id: 028e
+      handler: event*
+  - group: keyboard
+    evdev:
+      name: ASUS ROG Ally Config
+      vendor_id: 0b05
+      product_id: 1abe
+      handler: event*
+  - group: keyboard
+    unique: false
+    evdev:
+      name: Asus Keyboard
+      vendor_id: 0b05
+      product_id: 1abe
+      handler: event*
+  - group: imu
+    iio:
+      name: bmi323-imu
+      mount_matrix:
+        x: [1, 0, 0]
+        y: [0, -1, 0]
+        z: [0, 0, -1]
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchscreen
+
+# The ID of a device event mapping in the 'event_maps' folder
+capability_map_id: aly1

--- a/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: ASUS ROG Ally X
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      board_name: RC72LA
+      sys_vendor: ASUSTeK COMPUTER INC.
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad # Used for setting attributes on load
+    hidraw:
+      vendor_id: 0x0b05
+      product_id: 0x1b4c
+      interface_num: 2
+  - group: gamepad # Used for setting attributes on load
+    hidraw:
+      vendor_id: 0x0b05
+      product_id: 0x1b4c
+      interface_num: 5
+  - group: gamepad
+    evdev:
+      name: ASUS ROG Ally X Gamepad
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
+  - group: keyboard
+    unique: false
+    evdev:
+      name: Asus Keyboard
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
+  - group: imu
+    iio:
+      name: bmi323-imu
+      mount_matrix:
+        x: [1, 0, 0]
+        y: [0, -1, 0]
+        z: [0, 0, -1]
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchscreen
+
+# The ID of a device event mapping in the 'event_maps' folder
+capability_map_id: aly1

--- a/usr/share/inputplumber/devices/25-playtron-steam_deck.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-steam_deck.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Steam Deck
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches match. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: Galileo
+      sys_vendor: Valve
+      cpu_vendor: AuthenticAMD
+  - dmi_data:
+      product_name: Jupiter
+      sys_vendor: Valve
+      cpu_vendor: AuthenticAMD
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Gamepad
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x28de
+      product_id: 0x1205
+      interface_num: 2
+  # Touchscreen
+  - group: touchscreen
+    unique: false
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+    config:
+      touchscreen:
+        orientation: "right"
+  # Keyboard
+  - group: keyboard
+    evdev:
+      name: AT Translated Set 2 keyboard
+      phys_path: isa0060/serio0/input0
+      handler: event*
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchscreen
+  - touchpad


### PR DESCRIPTION
This change adds PlaytronOS-specific device configuration for several devices to enable touchscreen support by default. InputPlumber will try to load/match device configuration in numerical order, so prefixing the config name with `25-` will make InputPlumber considered these config before ones with `50-`.

> [!NOTE]  
> This change will require the generic touchscreen support in InputPlumber to be merged before including these overrides.