### PR TITLE
capture all volume/meta keys

### DIFF
--- a/usr/share/inputplumber/devices/25-playtron-ayaneo_2.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-ayaneo_2.yaml
@@ -57,6 +57,25 @@ source_devices:
     config:
       touchscreen:
         orientation: "right"
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyMute
 
 # Optional configuration for the composite device
 options:

--- a/usr/share/inputplumber/devices/25-playtron-ayaneo_2s.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-ayaneo_2s.yaml
@@ -57,6 +57,25 @@ source_devices:
     config:
       touchscreen:
         orientation: "right"
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyMute
 
 # Optional configuration for the composite device
 options:

--- a/usr/share/inputplumber/devices/25-playtron-legion_go.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-legion_go.yaml
@@ -159,6 +159,26 @@ source_devices:
       product_id: "618[3-5]"
       handler: event*
 
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyMute
+
 # Optional configuration for the composite device
 options:
   # If true, InputPlumber will automatically try to manage the input device. If

--- a/usr/share/inputplumber/devices/25-playtron-msi_claw.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-msi_claw.yaml
@@ -62,6 +62,26 @@ source_devices:
       sys_name: "event*"
       subsystem: input
 
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyMute
+
 # Optional configuration for the composite device
 options:
   # If true, InputPlumber will automatically try to manage the input device. If

--- a/usr/share/inputplumber/devices/25-playtron-rog_ally.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-rog_ally.yaml
@@ -60,6 +60,25 @@ source_devices:
           value: "1"
       sys_name: "event*"
       subsystem: input
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyMute
 
 # Optional configuration for the composite device
 options:

--- a/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
@@ -59,6 +59,25 @@ source_devices:
           value: "1"
       sys_name: "event*"
       subsystem: input
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyMute
 
 # Optional configuration for the composite device
 options:

--- a/usr/share/inputplumber/devices/25-playtron-steam_deck.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-steam_deck.yaml
@@ -51,6 +51,25 @@ source_devices:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0
       handler: event*
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyMute
 
 # Optional configuration for the composite device
 options:


### PR DESCRIPTION
This change modifies the InputPlumber device configuration to capture all keyboard devices to listen for meta and volume key events. 