### PR TITLE
Add dev session trigger

### DIFF
--- a/etc/xdg/weston/weston.ini
+++ b/etc/xdg/weston/weston.ini
@@ -2,6 +2,10 @@
 xwayland=true
 idle-time=0
 
+[output]
+name=eDP-1
+scale=2
+
 [launcher]
 icon=/usr/share/weston/icon_terminal.png
 path=/usr/bin/weston-terminal

--- a/usr/bin/playtron-weston
+++ b/usr/bin/playtron-weston
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+# the dev session switch is a one time thing, immediately
+# revert to the default/user session for next boot
+pkexec playtronos-session-select user --no-switch
+weston

--- a/usr/bin/playtronos-session-select
+++ b/usr/bin/playtronos-session-select
@@ -11,18 +11,31 @@ SESSION_OVERRIDE="/etc/sddm.conf.d/60-playtron-session-override.conf"
 SESSION_LIST=('user' 'dev')
 SELECTED_SESSION="$1"
 
+if [ "$2" = "--no-switch" ]; then
+	NO_SWITCH=1
+fi
 
 function dev() {
 	mkdir -p $(dirname $SESSION_OVERRIDE)
 
 	echo '
 [Autologin]
-Session=weston
+Session=playtron-weston
 ' > ${SESSION_OVERRIDE}
+
+	# workaround for touch screen not working in dev session
+	systemctl stop inputplumber
 }
 
 function user() {
 	rm -f ${SESSION_OVERRIDE}
+
+	# dev session calls this script again with the `--no-switch` argument to re-enable
+	# the user session, we don't want to start inputplumber in that case
+	if [ -z "${NO_SWITCH}" ]; then
+		# undo workaround for touch screen not working in dev session
+		systemctl start inputplumber
+	fi
 }
 
 function print_session_list() {
@@ -74,4 +87,6 @@ else
 	exit 1
 fi
 
-systemctl restart display-manager
+if [ -z "${NO_SWITCH}" ]; then
+	systemctl restart display-manager
+fi

--- a/usr/bin/playtronos-session-select
+++ b/usr/bin/playtronos-session-select
@@ -13,6 +13,9 @@ SELECTED_SESSION="$1"
 
 if [ "$2" = "--no-switch" ]; then
 	NO_SWITCH=1
+
+	# a workaround to fix touch input in the dev session
+	systemctl restart inputplumber
 fi
 
 function dev() {
@@ -22,20 +25,10 @@ function dev() {
 [Autologin]
 Session=playtron-weston
 ' > ${SESSION_OVERRIDE}
-
-	# workaround for touch screen not working in dev session
-	systemctl stop inputplumber
 }
 
 function user() {
 	rm -f ${SESSION_OVERRIDE}
-
-	# dev session calls this script again with the `--no-switch` argument to re-enable
-	# the user session, we don't want to start inputplumber in that case
-	if [ -z "${NO_SWITCH}" ]; then
-		# undo workaround for touch screen not working in dev session
-		systemctl start inputplumber
-	fi
 }
 
 function print_session_list() {

--- a/usr/bin/playtronos-session-select
+++ b/usr/bin/playtronos-session-select
@@ -1,0 +1,77 @@
+#! /bin/bash
+
+
+if [ $EUID -ne 0 ]; then
+	echo "$(basename $0) must be run as root"
+	exit 1
+fi
+
+
+SESSION_OVERRIDE="/etc/sddm.conf.d/60-playtron-session-override.conf"
+SESSION_LIST=('user' 'dev')
+SELECTED_SESSION="$1"
+
+
+function dev() {
+	mkdir -p $(dirname $SESSION_OVERRIDE)
+
+	echo '
+[Autologin]
+Session=weston
+' > ${SESSION_OVERRIDE}
+}
+
+function user() {
+	rm -f ${SESSION_OVERRIDE}
+}
+
+function print_session_list() {
+	# detect active session
+	CURRENT_SESSION="unknown"
+	if test -f ${SESSION_OVERRIDE}; then
+		CURRENT_SESSION="dev"
+	else
+		CURRENT_SESSION="user"
+	fi
+
+	# print active and available sessions
+	for t in ${SESSION_LIST[@]}; do
+		if [ "${CURRENT_SESSION}" = "${t}" ]; then
+			echo "* $t"
+		else
+			echo "  $t"
+		fi
+	done
+}
+
+function print_invalid_session() {
+	echo "Unknown or invalid session type: ${SELECTED_SESSION}"
+	echo
+	echo "Available session types:"
+	print_session_list
+}
+
+# print current and available sessions when no argument specified
+if [ -z "${SELECTED_SESSION}" ]; then
+	print_session_list
+	exit 0
+fi
+
+# print message when invalid session is specified
+if [[ ! "${SESSION_LIST[*]}" =~ "${SELECTED_SESSION}" ]]; then
+	print_invalid_session
+	exit 1
+fi
+
+# apply the specified session type
+if [ "${SELECTED_SESSION}" = "user" ]; then
+	echo "Switching to user session"
+	user
+elif [ "${SELECTED_SESSION}" = "dev" ]; then
+	echo "Switching to dev session"
+	dev
+else
+	exit 1
+fi
+
+systemctl restart display-manager

--- a/usr/libexec/playtron/dev-session-trigger
+++ b/usr/libexec/playtron/dev-session-trigger
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+import dbus
+from gi.repository import GLib
+from dbus.mainloop.glib import DBusGMainLoop
+
+state = {
+        'ui_action': 0.0,
+        'ui_r1': 0.0,
+        'ui_l1': 0.0,
+        'ui_l3': 0.0,
+}
+
+loop = GLib.MainLoop()
+result = 1
+
+def signal_handler(*args, **kwargs):
+    global loop, result
+
+    if len(args) < 2:
+        return
+
+    button = args[0]
+    new_state = args[1]
+    if button in state.keys():
+        state[button] = new_state
+
+    if state['ui_action'] and state['ui_r1'] and state['ui_l1'] and state['ui_l3']:
+        print('Combo detected, switching to dev session')
+        os.system('pkexec playtronos-session-select dev')
+        result = 0
+        loop.quit()
+
+
+
+DBusGMainLoop(set_as_default=True)
+GLib.timeout_add_seconds(30, lambda: loop.quit())
+bus = dbus.SystemBus()
+bus.add_signal_receiver(signal_handler, bus_name='org.shadowblip.InputPlumber')
+
+loop.run()
+exit(result)

--- a/usr/share/polkit-1/rules.d/50-one.playtron.playtronos-session-select.rules
+++ b/usr/share/polkit-1/rules.d/50-one.playtron.playtronos-session-select.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" && subject.isInGroup("wheel") && action.lookup("program") == "/usr/bin/playtronos-session-select") {
+        return polkit.Result.YES;
+    }
+});

--- a/usr/share/wayland-sessions/playtron-weston.desktop
+++ b/usr/share/wayland-sessions/playtron-weston.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Weston (Playtron)
+Comment=The reference Wayland server
+Exec=playtron-weston
+Type=Application


### PR DESCRIPTION
This PR allows for pressing L1+R1+Y+Left Stick button in the first 30 seconds of the playtron session to activate the dev session.

Sibling PR: https://github.com/playtron-os/gamescope-session-playtron/pull/7


- playtronos-session-select
    - move script from gamescope-session-playtron into this project (recommend to check the commit level diff to see the changes made to the session select script)
    - add a `--no-switch` flag for setting the session type without actually switching the session
    - stop inputplumber when starting dev session to make touchscreen work
- set 2x scaling to make touch screen more usable in weston on Aya Neo 2
- add a weston wrapper (playtron-weston) to allow making the dev session transient
- add `dev-session-trigger` python script which watches InputPlumber events via dbus for 30 seconds for a button combo, if detected, the session is switched to the dev session
- add polkit setting to allow `playtronos-session-select` to be called with `pkexec`, required to be able to automatically switch the session