### PR TITLE
reboot into dev session after trigger

### DIFF
--- a/usr/bin/playtronos-session-select
+++ b/usr/bin/playtronos-session-select
@@ -13,9 +13,6 @@ SELECTED_SESSION="$1"
 
 if [ "$2" = "--no-switch" ]; then
 	NO_SWITCH=1
-
-	# a workaround to fix touch input in the dev session
-	systemctl restart inputplumber
 fi
 
 function dev() {

--- a/usr/libexec/playtron/dev-session-trigger
+++ b/usr/libexec/playtron/dev-session-trigger
@@ -28,7 +28,8 @@ def signal_handler(*args, **kwargs):
 
     if state['ui_action'] and state['ui_r1'] and state['ui_l1'] and state['ui_l3']:
         print('Combo detected, switching to dev session')
-        os.system('pkexec playtronos-session-select dev')
+        os.system('pkexec playtronos-session-select dev --no-switch')
+        os.system('reboot')
         result = 0
         loop.quit()
 


### PR DESCRIPTION
Switching immediately into the dev session would cause the touch screen on the Aya Neo 2 to not function sometimes, even with the work around in place.

Instead, when the button combo is pressed, switch to the dev session (without actually performing the switch), then reboot.

Upon reboot, the dev session will start immediately and the touchscreen works 100% of the time.