### PR TITLE
Filter unused keyboard keys from Ayaneo 2/2s

### DIFF
--- a/usr/share/inputplumber/devices/25-playtron-ayaneo_2.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-ayaneo_2.yaml
@@ -40,6 +40,19 @@ source_devices:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0
       handler: event*
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightCtrl
+        - Keyboard:KeyD
+        - Keyboard:KeyF15
+        - Keyboard:KeyF16
+        - Keyboard:KeyF17
+        - Keyboard:KeyF18
   - group: imu
     iio:
       name: i2c-BMI0160:00

--- a/usr/share/inputplumber/devices/25-playtron-ayaneo_2s.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-ayaneo_2s.yaml
@@ -40,6 +40,19 @@ source_devices:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0
       handler: event*
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightCtrl
+        - Keyboard:KeyD
+        - Keyboard:KeyF15
+        - Keyboard:KeyF16
+        - Keyboard:KeyF17
+        - Keyboard:KeyF18
   - group: imu
     iio:
       name: i2c-BMI0160:00


### PR DESCRIPTION
This change will filter out unused keys from the Ayaneo 2/2s to prevent these keys from showing up as capabilities of the device.