### PR TITLE
Update 0x1 config and add hwdb entry for keyboard

### DIFF
--- a/usr/lib/udev/hwdb.d/59-sui.hwdb
+++ b/usr/lib/udev/hwdb.d/59-sui.hwdb
@@ -1,0 +1,6 @@
+# Mysten Labs Devices
+evdev:name:AT Translated Set 2 keyboard:dmi:*:svnMysten*:*
+  KEYBOARD_KEY_66=f15
+  KEYBOARD_KEY_67=f16
+  KEYBOARD_KEY_68=f17
+  KEYBOARD_KEY_69=f18

--- a/usr/share/inputplumber/devices/25-playtron-suiplay0x1.yaml
+++ b/usr/share/inputplumber/devices/25-playtron-suiplay0x1.yaml
@@ -17,6 +17,7 @@ single_source: false
 matches:
   - dmi_data:
       product_name: SuiPlay0X1
+      sys_vendor: Mysten Labs, Inc.
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
@@ -51,7 +52,7 @@ source_devices:
         - Keyboard:KeyF18
   - group: imu
     iio:
-      name: i2c-BMI0160:00
+      name: bmi323-imu
       mount_matrix:
         x: [0, -1, 0]
         y: [-1, 0, 0]


### PR DESCRIPTION
This change updates the inputplumber config for the SuiPlay 0x1 to capture the bmi323 gyro/accelerometer. It also includes a new hwdb entry that will correctly map the keyboard the device uses to send key combos with F[15-18] keys.

> [!NOTE]
> We will need to run `sudo systemd-hwdb update` somewhere in the build process to ensure that the new hwdb rule is included in the db.