### PR TITLE
enable powerstation service

### DIFF
--- a/usr/lib/systemd/system-preset/50-playtron.preset
+++ b/usr/lib/systemd/system-preset/50-playtron.preset
@@ -4,6 +4,7 @@ enable sddm.service
 enable NetworkManager-wait-online.service
 enable resize-root-file-system.service
 enable inputplumber.service
+enable powerstation.service
 enable wake-up-listener.service
 disable firewalld.service
 disable systemd-oomd.service


### PR DESCRIPTION
Powerstation is required for the hardware testing tool to be able to set a TDP limit.