### PR TITLE
Add serial test and udev rule to access serial interface

### DIFF
--- a/usr/lib/udev/rules.d/50-ayaneo2s.rules
+++ b/usr/lib/udev/rules.d/50-ayaneo2s.rules
@@ -1,0 +1,5 @@
+# Add the product name as an environment variable to any ttyS2 device
+KERNEL=="ttyS2", SUBSYSTEM=="tty", IMPORT{program}="/usr/bin/sh -c 'echo -n ID_PRODUCT_NAME= && cat /sys/class/dmi/id/product_name'"
+
+# Apply permissions to the serial interface if this is a valid Ayaneo 2S device
+KERNEL=="ttyS2", SUBSYSTEM=="tty", ENV{ID_PRODUCT_NAME}=="AYANEO 2S", TAG+="uaccess"

--- a/usr/lib/udev/rules.d/50-suiplay0x1.rules
+++ b/usr/lib/udev/rules.d/50-suiplay0x1.rules
@@ -1,0 +1,9 @@
+# Only apply permissions if the serial device appears on a SuiPlay0X1
+KERNEL=="ttyS2", IMPORT{program}="/usr/bin/sh -c 'echo -n ID_PRODUCT_NAME= && cat /sys/class/dmi/id/product_name'"
+KERNEL=="ttyS2", ENV{ID_PRODUCT_NAME}=="SuiPlay0X1", GOTO="suiplay0x1_valid"
+GOTO="suiplay0x1_end"
+
+# Apply permissions to the serial interface if this is a valid SuiPlay0X1 device
+LABEL="suiplay0x1_valid"
+KERNEL=="ttyS2", SUBSYSTEM=="tty", MODE:="0660", OWNER:="playtron", GROUP:="playtron"
+LABEL="suiplay0x1_end"

--- a/usr/lib/udev/rules.d/50-suiplay0x1.rules
+++ b/usr/lib/udev/rules.d/50-suiplay0x1.rules
@@ -1,9 +1,5 @@
-# Only apply permissions if the serial device appears on a SuiPlay0X1
-KERNEL=="ttyS2", IMPORT{program}="/usr/bin/sh -c 'echo -n ID_PRODUCT_NAME= && cat /sys/class/dmi/id/product_name'"
-KERNEL=="ttyS2", ENV{ID_PRODUCT_NAME}=="SuiPlay0X1", GOTO="suiplay0x1_valid"
-GOTO="suiplay0x1_end"
+# Add the product name as an environment variable to any ttyS2 device
+KERNEL=="ttyS2", SUBSYSTEM=="tty", IMPORT{program}="/usr/bin/sh -c 'echo -n ID_PRODUCT_NAME= && cat /sys/class/dmi/id/product_name'"
 
 # Apply permissions to the serial interface if this is a valid SuiPlay0X1 device
-LABEL="suiplay0x1_valid"
-KERNEL=="ttyS2", SUBSYSTEM=="tty", MODE:="0660", OWNER:="playtron", GROUP:="playtron"
-LABEL="suiplay0x1_end"
+KERNEL=="ttyS2", SUBSYSTEM=="tty", ENV{ID_PRODUCT_NAME}=="SuiPlay0X1", TAG+="uaccess"

--- a/usr/libexec/playtron/hardware-test-tool
+++ b/usr/libexec/playtron/hardware-test-tool
@@ -664,18 +664,37 @@ class SerialTest(PlaceholderTest):
 
         # Open the serial interface
         reader = open(DEVICE, "rb")
-        writer = open(DEVICE, "wb")
 
-        # Write a payload
-        writer.write(DATA)
-        writer.close()
+        # Write a payload. Writing the payload multiple times is required for
+        # older AYANEO 2S devices, which will only reply after a certain
+        # number of requests.
+        for _ in range(10):
+            writer = open(DEVICE, "wb")
+            writer.write(DATA)
+            writer.close()
+            time.sleep(0.1)
 
-        # Read the response
-        response = reader.read(5)
-        if response == EXPECTED_RESPONSE:
-            self.result = "pass"
-        else:
-            self.result = "fail"
+        # Read the response. Look for the header byte in the response to see
+        # if the request was successful.
+        for _ in range(10):
+            header = reader.read(1)
+            if header != b'\xE7':
+                continue
+            response = header + reader.read(4)
+            if len(response) != 5:
+                self.result = "fail"
+                break
+
+            # Byte 3 is the version, which can vary depending on model
+            if response[0] == EXPECTED_RESPONSE[0] and \
+               response[1] == EXPECTED_RESPONSE[1] and \
+               response[2] == EXPECTED_RESPONSE[2] and \
+               response[4] == EXPECTED_RESPONSE[4]:
+                self.result = "pass"
+            else:
+                self.result = "fail"
+            break
+
         reader.close()
 
     def draw(self, screen, font):

--- a/usr/libexec/playtron/hardware-test-tool
+++ b/usr/libexec/playtron/hardware-test-tool
@@ -638,7 +638,53 @@ class StressTest(PlaceholderTest):
                 self.stress_time = -1
 
 
+BAUD_RATE = 115200
+DEVICE = "/dev/ttyS2"
+DATA = b'\xE7\x00\x00\x22\x02\x00\x00\x00\x0F\x33\xED'
+EXPECTED_RESPONSE = b'\xE7\x55\xAA\x01\xED'
+class SerialTest(PlaceholderTest):
+    def __init__(self):
+        self.name = 'Serial Test|串行端口'
+        self.reset()
+        self.start_time = None
 
+    def start(self, screen, font):
+        self.reset()
+        self.start_time = time.perf_counter()
+
+        # Configure the serial port
+        cmd = "stty -F {device} {baud_rate}".format(device=DEVICE, baud_rate=BAUD_RATE)
+        if os.system(cmd) != 0:
+            self.result = "fail"
+            return
+        cmd = "stty -F {device} raw".format(device=DEVICE)
+        if os.system(cmd) != 0:
+            self.result = "fail"
+            return
+
+        # Open the serial interface
+        reader = open(DEVICE, "rb")
+        writer = open(DEVICE, "wb")
+
+        # Write a payload
+        writer.write(DATA)
+        writer.close()
+
+        # Read the response
+        response = reader.read(5)
+        if response == EXPECTED_RESPONSE:
+            self.result = "pass"
+        else:
+            self.result = "fail"
+        reader.close()
+
+    def draw(self, screen, font):
+        if self.start_time is None:
+            return
+        text = "Failed|失败的"
+        if self.result == "pass":
+            text = "Success|成功"
+        font.render_to(screen, (FONT_SIZE * 2, FONT_SIZE * 2), text, TEXT_COLOR)
 
 
 @dataclass
@@ -673,7 +719,7 @@ tests = [
     Test(test=StressTest(),      rect=pygame.Rect(TILE_W*1, TILE_H*5, TILE_W, TILE_H)),
     Test(test=PlaceholderTest(), rect=pygame.Rect(TILE_W*2, TILE_H*5, TILE_W, TILE_H)),
 
-    Test(test=PlaceholderTest(), rect=pygame.Rect(TILE_W*0, TILE_H*6, TILE_W, TILE_H)),
+    Test(test=SerialTest(),      rect=pygame.Rect(TILE_W*0, TILE_H*6, TILE_W, TILE_H)),
     Test(test=ExitAction(),      rect=pygame.Rect(TILE_W*1, TILE_H*6, TILE_W, TILE_H)),
     Test(test=PowerOffAction(),  rect=pygame.Rect(TILE_W*2, TILE_H*6, TILE_W, TILE_H)),
 ]


### PR DESCRIPTION
This change adds a test for the serial interface and a udev rule to allow accessing the gamepad serial interface as the normal `playtron` user.

The udev rule works by matching any device node with the name `ttyS2` and uses `IMPORT{program}` to set a udev environment variable on the device called `ID_PRODUCT_NAME` with the product name. Then, if `ID_PRODUCT_NAME` matches "SuiPlay0X1", we apply the permissions/ownership to the device node. If the product name does _not_ match, then this rule will do nothing, so it should not affect any other devices that may also have a `ttyS2`.

The test itself will send a pre-written payload to the serial interface and will pass if we get back the expected response.