### PR TITLE
run trigger until FTUE completes

### DIFF
--- a/usr/libexec/playtron/dev-session-trigger
+++ b/usr/libexec/playtron/dev-session-trigger
@@ -15,6 +15,14 @@ state = {
 loop = GLib.MainLoop()
 result = 1
 
+
+def check_exit():
+    if os.path.exists(os.path.join(os.environ.get('HOME'), '.local/share/playtron/tools')):
+        loop.quit()
+    else:
+        GLib.timeout_add_seconds(30, check_exit)
+
+
 def signal_handler(*args, **kwargs):
     global loop, result
 
@@ -36,9 +44,10 @@ def signal_handler(*args, **kwargs):
 
 
 DBusGMainLoop(set_as_default=True)
-GLib.timeout_add_seconds(30, lambda: loop.quit())
 bus = dbus.SystemBus()
 bus.add_signal_receiver(signal_handler, bus_name='org.shadowblip.InputPlumber')
+
+check_exit()
 
 loop.run()
 exit(result)


### PR DESCRIPTION
Sibling PR: https://github.com/playtron-os/gamescope-session-playtron/pull/9

When the FTUE starts, `~/.local/share/playtron/tools` does not exist, so using the existence of this directory as a proxy for FTUE completion.

We check every 30 seconds if the directory exists so that we do not run forever on first boot.

The playtron session has a similar check (see sibling PR) so that this trigger script is completely skipped on subsequent boots.


Testing procedure:
 - start system
 - leave it on the FTUE for a few minutes
 - press button combo
 - allow system to restart into dev session
 - open hardware testing tool
 - select power off
 - turn on system again
 - complete FTUE
 - wait a few minutes
 - attempt button combo a few times
 - system does not reboot
 - check that dev-session-trigger process is not running
 - reboot the system manually
 - attempt button combo a few times, immediately when Grid starts
 - system does not reboot
 - check that dev-session-trigger process is not running
