### PR TITLE
ensure noise filtering is enabled when starting the hardware test tool

### DIFF
--- a/usr/lib/systemd/user/pipewire-rnnoise-switch.service
+++ b/usr/lib/systemd/user/pipewire-rnnoise-switch.service
@@ -4,7 +4,7 @@ After=pipewire-rnnoise.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'wpctl set-default $(wpctl status | grep output.rnnoise_source | awk '\''{print $2}'\'' | cut -d. -f1)'
+ExecStart=/bin/sh -c "wpctl set-default $(wpctl status | grep output.rnnoise_source | grep -oP '([0-9]+)' | head -1)"
 ExecStart=/bin/systemctl --no-reload --user disable %n
 
 [Install]

--- a/usr/libexec/playtron/hardware-test-tool
+++ b/usr/libexec/playtron/hardware-test-tool
@@ -811,6 +811,9 @@ tests = [
     Test(test=PowerOffAction(), rect=pygame.Rect(TILE_W*2, TILE_H*6, TILE_W, TILE_H)),
 ]
 
+# set default input device to noise filtered virtual device
+os.system('systemctl --user start pipewire-rnnoise-switch')
+
 # set default volume levels
 os.system(f'hwctl audio set-volume {DEFAULT_OUTPUT_VOLUME}')
 os.system(f'hwctl audio-input set-volume {DEFAULT_INPUT_VOLUME}')


### PR DESCRIPTION
The wpctl command being run by the service was failing to set the default output, so I fixed that as well.