### PR TITLE
update bios glob pattern for future bios releases

### DIFF
--- a/usr/share/inputplumber/devices/24-playtron-ayaneo_2s_v2.yaml
+++ b/usr/share/inputplumber/devices/24-playtron-ayaneo_2s_v2.yaml
@@ -18,11 +18,11 @@ matches:
   - dmi_data:
       product_name: AYANEO 2S
       sys_vendor: AYANEO
-      bios_version: "2.19_*"
+      bios_version: "[2-9].{19,[2-9][0-9]}_*"
   - dmi_data:
       product_name: GEEK 1S
       sys_vendor: AYANEO
-      bios_version: "2.19_*"
+      bios_version: "[2-9].{19,[2-9][0-9]}_*"
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/usr/share/inputplumber/devices/24-playtron-suiplay0x1_v2.yaml
+++ b/usr/share/inputplumber/devices/24-playtron-suiplay0x1_v2.yaml
@@ -18,7 +18,7 @@ matches:
   - dmi_data:
       product_name: SuiPlay0X1
       sys_vendor: Mysten Labs, Inc.
-      bios_version: "2.19_*"
+      bios_version: "[2-9].{19,[2-9][0-9]}_*"
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.


### PR DESCRIPTION
This change updates the bios glob pattern to match bios versions `2.19` - `9.99`