### PR TITLE
Adjust default volume levels for test tool

### DIFF
--- a/usr/libexec/playtron/hardware-test-tool
+++ b/usr/libexec/playtron/hardware-test-tool
@@ -773,8 +773,8 @@ class SerialTest(PlaceholderTest):
 
 
 
-DEFAULT_OUTPUT_VOLUME = 80
-DEFAULT_INPUT_VOLUME = 80
+DEFAULT_OUTPUT_VOLUME = 100
+DEFAULT_INPUT_VOLUME = 60
 
 @dataclass
 class Test:


### PR DESCRIPTION
Change default volume levels for the hardware test tool by request.

Tested these levels manually with the speaker test to make sure the levels were reasonable.