### PR TITLE
add firmware update functionality

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -114,7 +114,7 @@ function system-info {
 
 }
 
-function firmware {
+function firmware-info {
 	fwupdmgr get-devices --json > /tmp/hwctl-devices.json
 	fwupdmgr get-updates --json > /tmp/hwctl-updates.json
 
@@ -151,6 +151,29 @@ function firmware {
 	    ]
 	  }
 	' /tmp/hwctl-devices.json /tmp/hwctl-updates.json
+}
+
+function firmware-update {
+	if [ -z $1 ]; then
+		echo "Please specify the device id to update"
+		exit 1
+	fi
+
+	fwupdmgr --assume-yes update $1
+}
+
+function firmware {
+	case $1 in
+		"info")
+			firmware-info
+			;;
+		"update")
+			firmware-update $2
+			;;
+		*)
+			echo "Error: unknown command"
+			;;
+	esac
 }
 
 function storage {


### PR DESCRIPTION
- Introduce `hwctl firmware update`, a simple wrapper around `fwupdmgr update`
- Move the existing `hwctl firmware` command to `hwctl firmware info`

Initially planned to have `fwupdmgr update` called directly since the wrapper doesn't really do much, however, that would require configuring elevated privileges for that command. Having `fwupdmgr update` called through `hwctl` allows us to reuse the elevated privileges already afforded to `hwctl`.

Make sure to call the command like so: `pkexec hwctl firmware update <device id>`.