### PR TITLE
add a "NeedsReboot" field to device firmware info

### DIFF
--- a/usr/bin/hwctl
+++ b/usr/bin/hwctl
@@ -147,6 +147,7 @@ function firmware-info {
 	        Vendor,
 	        Version,
 	        UpdateVersion: ($updates[.DeviceId].UpdateVersion // null),
+	        NeedsReboot: ((.Flags // []) | contains(["needs-reboot"])),
 	      }
 	    ]
 	  }


### PR DESCRIPTION
- Add a boolean "NeedsReboot" field for each device which indicates whether the system/OS should be rebooted after a firmware update is completed for that device

Example output:
```
{
  "Devices": [
    {
      "DeviceId": "21ba7fbcdfb80c824895aad926418475726bcc79",
      "Name": "Navi 32 [Radeon RX 7700 XT / 7800 XT]",
      "Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]",
      "Version": "100",
      "UpdateVersion": null,
      "NeedsReboot": true
    },
    {
      "DeviceId": "71b677ca0f1bc2c5b804fa1d59e52064ce589293",
      "Name": "SSD 970 EVO Plus 1TB",
      "Vendor": "Samsung",
      "Version": "2B2QEXM7",
      "UpdateVersion": null,
      "NeedsReboot": false
    }
  ]
}

```

Note that the "NeedsReboot" field value is specific to the device, and does not vary from update to update. The value does not change based on whether an update was completed or not, or whether an update is available. It will always stay the same value for each given device.