### PR TITLE
Add 'playtronos-systemreport' command to collect logs and system info

### DIFF
--- a/usr/bin/playtronos-systemreport
+++ b/usr/bin/playtronos-systemreport
@@ -1,0 +1,131 @@
+#!/bin/bash
+# System Report
+#
+# Generates a system report archive which can contain useful information for
+# reporting bugs and troubleshooting.
+
+if [ $EUID -ne 0 ]; then
+  echo "$(basename "$0") must be run as root"
+  exit 1
+fi
+
+ENDCOLOR='\e[0m'
+RED='\e[0;31m'
+PURPLE='\e[0;35m'
+CYAN='\e[0;36m'
+
+TARGET_USER=playtron
+TARGET_UID=$(id -u "${TARGET_USER}")
+REPORT_NAME="report-$(date +%Y-%m-%d-%s)"
+REPORT_DIR_BASE="$(mktemp -d)"
+REPORT_DIR="${REPORT_DIR_BASE}/${REPORT_NAME}"
+mkdir -p "${REPORT_DIR}"
+
+echo -e "${CYAN}Generating system report...${ENDCOLOR}"
+
+# OS
+echo -e "  Collecting ${RED}os${ENDCOLOR} report..."
+rpm-ostree status >"${REPORT_DIR}/rpm-ostree.out" 2>&1
+
+# Hardware
+echo -e "  Collecting ${RED}hardware${ENDCOLOR} report..."
+dmesg >"${REPORT_DIR}/dmesg.log"
+lspci -tv -nn >"${REPORT_DIR}/lspci.out"
+lsusb -t -v >"${REPORT_DIR}/lsusb.out"
+cat /proc/bus/input/devices >"${REPORT_DIR}/input-devices.out"
+hwctl system-info >"${REPORT_DIR}/system.json" 2>/dev/null
+
+# Firmware
+echo -e "  Collecting ${RED}firmware${ENDCOLOR} report..."
+fwupdmgr get-devices >"${REPORT_DIR}/firmware-devices.out" 2>&1
+echo "BIOS version: $(cat /sys/class/dmi/id/bios_version)" >>"${REPORT_DIR}/firmware-devices.out"
+fwupdmgr get-updates -y >"${REPORT_DIR}/firmware-updates.out" 2>&1
+
+# Processes
+echo -e "  Collecting ${RED}process${ENDCOLOR} report..."
+ps afux >"${REPORT_DIR}/processes.out"
+
+# Input
+echo -e "  Collecting ${RED}input${ENDCOLOR} report..."
+timeout 0.3 evtest >"${REPORT_DIR}/evtest.out" 2>&1
+{
+  echo "InputPlumber State"
+  echo ""
+  echo "\$ inputplumber devices list"
+  inputplumber devices list
+  echo "\$ inputplumber device 0 info"
+  inputplumber device 0 info
+  echo "\$ inputplumber device 0 intercept get"
+  inputplumber device 0 intercept get
+  echo "\$ inputplumber device 0 targets list"
+  inputplumber device 0 targets list
+} >"${REPORT_DIR}/inputplumber.out" 2>&1
+
+# Power/TDP/Battery
+echo -e "  Collecting ${RED}power${ENDCOLOR} report..."
+busctl introspect org.shadowblip.PowerStation /org/shadowblip/Performance/GPU/card0 >"${REPORT_DIR}/powerstation.out"
+upower -d >"${REPORT_DIR}/battery.out" 2>&1
+
+# System logs
+echo -e "  Collecting ${RED}services${ENDCOLOR} report..."
+journalctl -b 0 >"${REPORT_DIR}/journal.log"
+journalctl -b 0 -u inputplumber >"${REPORT_DIR}/inputplumber.log"
+journalctl -b 0 -u powerstation >"${REPORT_DIR}/powerstation.log"
+sudo -u "${TARGET_USER}" journalctl --user -u playserve -b >"${REPORT_DIR}/playserve.log"
+sudo -u "${TARGET_USER}" journalctl --user -u gamescope-dbus -b >"${REPORT_DIR}/gamescope-dbus.log"
+sudo -u "${TARGET_USER}" journalctl --user -u gamescope-session-plus@playtron -b >"${REPORT_DIR}/gamescope-session.log"
+
+# Gamescope
+echo -e "  Collecting ${RED}gamescope${ENDCOLOR} report..."
+{
+  echo "\$ xprop -display :0 -root"
+  sudo -u "${TARGET_USER}" xprop -display :0 -root
+  echo ""
+  echo "\$ xwininfo -display :0 -root -children -int"
+  sudo -u "${TARGET_USER}" xwininfo -display :0 -root -children -int
+  echo ""
+  echo "\$ xwininfo -display :1 -root -children -int"
+  sudo -u "${TARGET_USER}" xwininfo -display :1 -root -children -int
+} >"${REPORT_DIR}/gamescope.out" 2>&1
+
+# Audio
+echo -e "  Collecting ${RED}audio${ENDCOLOR} report..."
+sudo -u "${TARGET_USER}" XDG_RUNTIME_DIR="/run/user/${TARGET_UID}" wpctl status >"${REPORT_DIR}/audio.out" 2>&1
+
+# Storage
+echo -e "  Collecting ${RED}storage${ENDCOLOR} report..."
+{
+  echo "\$ lsblk -f"
+  lsblk -f
+  echo ""
+  echo "\$ mount"
+  mount
+  echo ""
+  echo "\$ df -h"
+  df -h
+} >"${REPORT_DIR}/storage.out"
+
+# Network
+echo -e "  Collecting ${RED}network${ENDCOLOR} report..."
+{
+  nmcli --overview
+  echo ""
+  ip addr
+  echo ""
+  ping -4 -c4 1.1.1.1
+  ping -4 -c4 8.8.8.8
+  echo ""
+  echo "dig +short playtron.one"
+  dig +short playtron.one
+} >"${REPORT_DIR}/network.out" 2>&1
+
+# Build the archive
+echo ""
+echo -e "${CYAN}Building report archive${ENDCOLOR}"
+cd "${REPORT_DIR_BASE}" && tar cvfz "${REPORT_NAME}.tar.gz" "${REPORT_NAME}"
+mv "${REPORT_DIR}.tar.gz" "/tmp/${REPORT_NAME}.tar.gz"
+chown ${TARGET_USER}: "/tmp/${REPORT_NAME}.tar.gz"
+rm -rf "${REPORT_DIR_BASE}"
+
+echo ""
+echo -e "Saved system report to: ${PURPLE}/tmp/${REPORT_NAME}.tar.gz${ENDCOLOR}"


### PR DESCRIPTION
This change adds a new `playtronos-systemreport` command which will collect a variety of logs and system state that can be very useful for reporting bugs and troubleshooting.

![image](https://github.com/user-attachments/assets/9bf8a209-4c56-4b8b-8626-1250e732403d)

The script collects a variety of information and creates a tar archive with all the information in various reports.